### PR TITLE
adding esb configs to chef

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -175,6 +175,7 @@ rbenv_gem 'bundle'
 
 opt_deploy_key = ChefVault::Item.load('deploy', 'opt') # gets ssl cert from chef-vault
 bridge_secrets = ChefVault::Item.load('secrets', 'oauth2') # gets bridge secret from vault.
+esb_secrets = ChefVault::Item.load('secrets', 'esb') # gets ESB secret from vault.
 rails_secrets = ChefVault::Item.load('secrets', 'rails_secret_tokens')
 recaptcha_secrets = ChefVault::Item.load('recaptcha_secrets', fqdn)
 smtp_settings = ChefVault::Item.load('smtp', fqdn)
@@ -191,6 +192,11 @@ opt app_name do
   shib_client_name shib_client
   shib_secret bridge_secrets[shib_client]
   shib_site 'https://onlinepoll.ucla.edu'
+  esb_user esb_secrets["#{app_name}_user"]
+  esb_pass esb_secrets["#{app_name}_pass"]
+  esb_auth_url esb_secrets["#{app_name}_auth_url"]
+  esb_cert esb_secrets["#{app_name}_cert"]
+  esb_key esb_secrets["#{app_name}_key"]
   secret rails_secrets[fqdn]
   recaptcha_public_key recaptcha_secrets['public']
   recaptcha_private_key recaptcha_secrets['private']


### PR DESCRIPTION
@StillSlippery Need to import secretes into vault:

This is a sample `secrets_esb.json` file:

```json
{
        "prod_user": "oit_srs",
        "prod_pass" : "",
        "prod_auth_url": "https://webservices.it.ucla.edu:4443/oauth2/token",
        "prod_cert" : "/etc/ssl/certs/onlinepoll.ucla.edu.crt",
        "prod_key" : "/home/opt/.ssl/onlinepoll.ucla.edu.key",
        "staging_user": "oit_srs",
        "staging_pass": "",
        "staging_auth_url": "https://webservicesqa.it.ucla.edu:4443/oauth2/token",
        "staging_cert" : "/etc/ssl/certs/staging.onlinepoll.ucla.edu.crt",
        "staging_key" : "/home/opt/.ssl/staging.onlinepoll.ucla.edu.key"
}

```

I believe this is how you import that file -- do sanity check on that:

```sh
$ knife vault create secrets esb '' \
  --search "fqdn:staging.m.ucla.edu OR fqdn:onlinepoll.ucla.edu"
```